### PR TITLE
Remove company-keywords support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ This package includes some extensions on top of the great Emacs `vhdl-mode`.
 * [Enhanced support for `which-func`](#which-func)
 * [Improve code folding via `hideshow`](#code-folding)
 * [Auto-configure `time-stamp`](#time-stamp)
-* [Auto-configure `company-keywords`](#company-keywords)
 * [Port connection utilities](#port-connections)
 
 ## Installation ##
@@ -65,7 +64,6 @@ By default all features are enabled:
         which-func
         hideshow
         time-stamp
-        company-keywords
         ports))
 (vhdl-ext-mode-setup)
 (add-hook 'vhdl-mode-hook #'vhdl-ext-mode)
@@ -98,7 +96,6 @@ If installed and loaded via `use-package`:
           which-func
           hideshow
           time-stamp
-          company-keywords
           ports))
   :config
   (vhdl-ext-mode-setup))
@@ -254,11 +251,6 @@ Automatic update of header timestamp after file saving.
    - `vhdl-ext-time-stamp-mode`
 
 For configuration see [wiki](https://github.com/gmlarumbe/vhdl-ext/wiki/Time-stamp)
-
-
-## Company keywords ##
-
-Setup `company` to complete with VHDL keywords.
 
 
 ## Port connections ##

--- a/vhdl-ext-utils.el
+++ b/vhdl-ext-utils.el
@@ -26,7 +26,6 @@
 
 (require 'project)
 (require 'vhdl-mode)
-(require 'company-keywords)
 
 
 (defcustom vhdl-ext-file-extension-re "\\.vhdl?\\'"
@@ -535,11 +534,6 @@ search."
                                " ")))
     (concat args (when extra-args (concat " " extra-args))" " dirs-args)))
 
-;;;; Misc
-(defun vhdl-ext-company-keywords-add ()
-  "Add `vhdl-keywords' to `company-keywords' backend."
-  (dolist (mode '(vhdl-mode vhdl-ts-mode))
-    (add-to-list 'company-keywords-alist `(,mode ,@vhdl-keywords))))
 
 ;;;; Overrides
 ;; TODO: To be fixed @ emacs/main

--- a/vhdl-ext.el
+++ b/vhdl-ext.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/gmlarumbe/vhdl-ext
 ;; Version: 0.2.0
 ;; Keywords: VHDL, IDE, Tools
-;; Package-Requires: ((emacs "29.1") (vhdl-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.0") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (flycheck "32") (company "0.9.13") (outshine "3.0.1") (async "1.9.7"))
+;; Package-Requires: ((emacs "29.1") (vhdl-ts-mode "0.0.0") (eglot "1.9") (lsp-mode "8.0.0") (ag "0.48") (ripgrep "0.4.0") (hydra "0.15.0") (flycheck "32") (outshine "3.0.1") (async "1.9.7"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -37,7 +37,6 @@
 ;;  - Enhanced support for `which-func'
 ;;  - Improve code folding via `hideshow'
 ;;  - Auto-configure `time-stamp'
-;;  - Automatically add VHDL keywords to `company-keywords' backend
 ;;  - Port connections utilities
 ;;
 ;;  Experimental:
@@ -66,7 +65,6 @@
                                    which-func
                                    hideshow
                                    time-stamp
-                                   company-keywords
                                    ports)
   "Which Vhdl-ext features to enable."
   :type '(set (const :tag "Improved syntax highlighting via `font-lock'."
@@ -99,8 +97,6 @@
                 hideshow)
               (const :tag "`time-stamp' configuration."
                 time-stamp)
-              (const :tag "Add `vhdl-keywords' to `company-keywords' backend."
-                company-keywords)
               (const :tag "Port connections utilities."
                 ports))
   :group 'vhdl-ext)
@@ -178,8 +174,6 @@ FEATURES can be a single feature or a list of features."
     (vhdl-ext-hierarchy-setup))
   (vhdl-ext-when-feature 'hideshow
     (vhdl-ext-hs-setup))
-  (vhdl-ext-when-feature 'company-keywords
-    (vhdl-ext-company-keywords-add))
   (vhdl-ext-when-feature 'font-lock
     (vhdl-ext-font-lock-setup))
   (vhdl-ext-when-feature 'eglot


### PR DESCRIPTION
`vhdl-keywords` completions are now added by `vhdl-ext-capf`.

This removes depending on `company-keywords` and `company` while allowing completion with other `completion-at-point` based packages.

In case someone is still interested in using `company-keywords`:
```elisp
(defun vhdl-ext-company-keywords-add ()
  "Add `vhdl-keywords' to `company-keywords' backend."
  (dolist (mode '(vhdl-mode vhdl-ts-mode))
    (add-to-list 'company-keywords-alist `(,mode ,@vhdl-keywords))))
```