### PR TITLE
Specify project directories and files with glob syntax

### DIFF
--- a/vhdl-ext-utils.el
+++ b/vhdl-ext-utils.el
@@ -344,13 +344,68 @@ search."
   (with-temp-file out-file
     (insert (mapconcat #'identity filelist "\n"))))
 
-(defun vhdl-ext-expand-file-list (file-list &optional rel-dir)
-  "Expand files in FILE-LIST.
+(defun vhdl-ext-is-globstar-dir (globstar-dir)
+  "Return non-nil if GLOBSTAR-DIR is a supported globstar string.
 
-Expand with respect to REL-DIR if non-nil."
-  (mapcar (lambda (file)
-            (expand-file-name file rel-dir))
-          file-list))
+Perform some checks to ensure that if there is a globstar pattern it is
+supported."
+  (let* ((globstar-re "/\\*\\*/.+")
+         (glob-re "\\*")
+         (globstar-pos (string-match globstar-re globstar-dir)))
+    (when globstar-pos
+      (cond (;; Search for simple glob after latest dir slash /))
+             (string-match glob-re globstar-dir (+ 3 globstar-pos))
+             (error "Unsupported globstar/glob expression: %s" globstar-dir))
+            (t ; Valid pattern
+             globstar-pos)))))
+
+(defun vhdl-ext-globstar-dirs (globstar-dir)
+  "Return list of directories that match GLOBSTAR-DIR expression.
+
+Globstar expressions are of the form: /home/user/dir/**/src
+
+This function returns subdirectories recursively."
+  (let* ((recursive t)
+         (globstar-re "\\*\\*")
+         (globstar-pos (string-match globstar-re globstar-dir))
+         (subdirs-substring-start (1+ (string-match "/" globstar-dir globstar-pos)))
+         (base-dir (substring-no-properties globstar-dir 0 globstar-pos))
+         (predicate-dirs (when subdirs-substring-start
+                           (string-trim-right (substring-no-properties globstar-dir subdirs-substring-start) "/+")))
+         (filter-re (when predicate-dirs
+                      (concat base-dir ".+" "\\<" predicate-dirs "\\>" (unless recursive "\\'"))))
+         all-dirs)
+    (when (and globstar-pos filter-re)
+      ;; Keep only directories, discard files
+      (setq all-dirs (seq-remove (lambda (x) (not (file-directory-p x)))
+                                 (directory-files-recursively base-dir "." t)))
+      ;; Return directories that match path after globstar
+      (seq-filter (lambda (dir) (string-match-p filter-re dir)) all-dirs))))
+
+(defun vhdl-ext-expand-file-list (file-list &optional rel-dir dir-list-p)
+  "Expand files/directories in FILE-LIST.
+
+Expand with respect to REL-DIR if non-nil.
+
+Expand glob patterns if present in the filename.
+
+If optional arg DIR-LIST-P is non-nil, assume FILE-LIST is a list of directories
+and return a list of expanded directories excluding files."
+  (let ((exp-file-list (mapcar (lambda (file)
+                                 (expand-file-name file rel-dir))
+                               file-list))
+        glob-exp-file-list)
+    ;; Seq is a list of files/directories after relative path pattern expansion
+    (dolist (exp-file exp-file-list (nreverse glob-exp-file-list))
+      ;; If it is a globstar dir, expand its directories and add them to the ones to be returned
+      (if (and dir-list-p (vhdl-ext-is-globstar-dir exp-file))
+          (dolist (globstar-dir (vhdl-ext-globstar-dirs exp-file))
+            (push globstar-dir glob-exp-file-list))
+        ;; Else process glob/regular files/dirs
+        (dolist (glob-exp-file (file-expand-wildcards (directory-file-name exp-file))) ; `file-expand-wildcards' needs a filename, not a dirname (withouth / at the end)
+          (unless (and dir-list-p
+                       (not (file-directory-p glob-exp-file)))
+            (push glob-exp-file glob-exp-file-list)))))))
 
 ;;;; File entities
 (defun vhdl-ext-scan-buffer-entities-and-lines ()
@@ -568,13 +623,22 @@ These depend on the value of property list of `vhdl-ext-project-alist'.
          (proj-ignore-dirs (plist-get proj-plist :ignore-dirs))
          (proj-files (plist-get proj-plist :files))
          (proj-ignore-files (plist-get proj-plist :ignore-files))
-         files-dirs files-all)
+         files-dirs files-all proj-dirs-all)
     ;; Basic checks
     (unless proj
       (user-error "Not in a VHDL project buffer, check `vhdl-ext-project-alist'"))
     (unless proj-root
       (user-error "Project root not set for project %s" proj))
-    ;; Expand filenames (except for proj-dirs since they need to parse the -r recursive flag)
+    ;; Expand filenames (relative path and glob patterns)
+    (when proj-dirs
+      (setq proj-dirs (dolist (dir proj-dirs (nreverse proj-dirs-all))
+                        (if (string= "-r" (car (split-string dir)))
+                            (dolist (elm (mapcar (lambda (recursive-dir)
+                                                   (concat "-r " recursive-dir))
+                                                 (vhdl-ext-expand-file-list (cdr (split-string dir)) proj-root :dir-list-p)))
+                              (push elm proj-dirs-all))
+                          (dolist (elm (vhdl-ext-expand-file-list `(,dir) proj-root :dir-list-p))
+                            (push elm proj-dirs-all))))))
     (when proj-ignore-dirs
       (setq proj-ignore-dirs (vhdl-ext-expand-file-list proj-ignore-dirs proj-root)))
     (when proj-files
@@ -585,8 +649,8 @@ These depend on the value of property list of `vhdl-ext-project-alist'.
     (when proj-dirs
       (mapc (lambda (dir)
               (if (string= "-r" (car (split-string dir)))
-                  (setq files-dirs (append files-dirs (vhdl-ext-dir-files (expand-file-name (cadr (split-string dir)) proj-root) :recursive :follow-symlinks proj-ignore-dirs)))
-                (setq files-dirs (append files-dirs (vhdl-ext-dir-files (expand-file-name dir proj-root) nil :follow-symlinks proj-ignore-dirs)))))
+                  (setq files-dirs (append files-dirs (vhdl-ext-dir-files (cadr (split-string dir)) :recursive :follow-symlinks proj-ignore-dirs)))
+                (setq files-dirs (append files-dirs (vhdl-ext-dir-files dir nil :follow-symlinks proj-ignore-dirs)))))
             proj-dirs))
     ;; If no dirs or files are specified get recursively all files in root
     (if (and (not proj-files)


### PR DESCRIPTION
This PR adds support for the glob and globstar patterns to specify files and dirs with the `vhdl-ext-project-alist` variable. For example:

- /proj_root/rtl/*/src
- /proj_root/rtl/*/tb
- /proj_root/block/rtl/*.vhd
- /proj_root/block/tb/*.vhdl
- /proj_root/**/tb