### PR TITLE
Update vhdl-ghdl flycheck definition

### DIFF
--- a/vhdl-ext-flycheck.el
+++ b/vhdl-ext-flycheck.el
@@ -93,7 +93,7 @@ See URL `https://github.com/ghdl/ghdl'."
   :error-patterns
   ((info    line-start (file-name) ":" line ":" column ":note: "    (message) line-end)
    (warning line-start (file-name) ":" line ":" column ":warning: " (message) line-end)
-   (error   line-start (file-name) ":" line ":" column ": "         (message) line-end))
+   (error   line-start (file-name) ":" line ":" column ":"         (message) line-end))
   :modes (vhdl-mode vhdl-ts-mode))
 
 


### PR DESCRIPTION
The error messages produced by GHDL do not have a trailing space. Update to amend this.